### PR TITLE
Bump version to 4.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            3.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ group = com.enonic.app
 projectName = gitpull
 appName = com.enonic.app.gitpull
 xpVersion = 8.0.0-B4
-version = 3.1.1-SNAPSHOT
+version = 4.0.0-SNAPSHOT


### PR DESCRIPTION
Bumps `master` to the next major SNAPSHOT in preparation for XP 8 development. The XP 7 maintenance line continues on the new `3.x` branch (created at `dce6290`, the post-`v3.1.0` "Updated to next SNAPSHOT version" commit).

## Changes

- `gradle.properties`: `version = 3.1.1-SNAPSHOT` → `version = 4.0.0-SNAPSHOT`
- `.github/workflows/enonic-gradle.yml`: add `releaseBranch:` block listing both `master` and `3.x` so the release tooling treats both branches as release branches.

A companion PR against `3.x` adds the same `releaseBranch:` config there (the action reads `releaseBranch:` from each branch's own workflow file).

Reference: app-booster's `master` ↔ `1.x` setup.