### PR TITLE
Add release-branch CI config for 3.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -1,117 +1,29 @@
 name: Gradle Build
 
-on: [push]
+on: [ push ]
 
 jobs:
   build:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.build-and-publish.outputs.release }}
+    steps:
+      - id: build-and-publish
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          repoUser: ci
+          repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            3.x
 
+  release:
     runs-on: ubuntu-latest
 
-    needs: release_notes
+    needs: build
+    if: needs.build.outputs.release == 'true'
 
     steps:
-      - uses: actions/checkout@v2.3.1
-
-      - uses: actions/setup-java@v1
+      - uses: enonic/release-tools/release@master
         with:
-          java-version: 11
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - run: ./gradlew build
-
-      - uses: codecov/codecov-action@v1.0.13
-
-      ### PUBLISHING STEPS ###
-
-      - name: Get publishing variables
-        id: publish_vars
-        uses: enonic/release-tools/publish-vars@master
-        env:
-          PROPERTIES_PATH: './gradle.properties'
-          JAVA_HOME: ''
-
-      - name: Fail on bad config
-        if: steps.publish_vars.outputs.version == '' || steps.publish_vars.outputs.projectName == ''
-        run: exit 1
-
-      - name: Publish
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: ./gradlew publish -PrepoKey=${{ steps.publish_vars.outputs.repo }} -PrepoUser=${{ secrets.ARTIFACTORY_USERNAME }} -PrepoPassword=${{ secrets.ARTIFACTORY_PASSWORD }}
-
-      - name: Download changelog
-        if: steps.publish_vars.outputs.release == 'true'
-        uses: actions/download-artifact@v2
-        with:
-          name: changelog
-
-      - name: Create Release
-        if: steps.publish_vars.outputs.release == 'true'
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.publish_vars.outputs.tag_name }}
-          body_path: changelog.md
-          prerelease: ${{ steps.publish_vars.outputs.prerelease == 'true' }}
-
-      - name: Upload Release Asset
-        id: upload-release-asset
-        if: "steps.create_release.outputs.upload_url != ''"
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: "build/libs/${{ steps.publish_vars.outputs.projectName }}-${{ steps.publish_vars.outputs.version }}.jar"
-          asset_name: "${{ steps.publish_vars.outputs.projectName }}-${{ steps.publish_vars.outputs.version }}.jar"
-          asset_content_type: application/java-archive
-
-      - name: Write new snapshot version
-        if: steps.publish_vars.outputs.release == 'true'
-        uses: christian-draeger/write-properties@1.0.1
-        with:
-          path: './gradle.properties'
-          property: 'version'
-          value: ${{ steps.publish_vars.outputs.nextSnapshot }}
-
-      - name: Commit and push new version
-        if: steps.publish_vars.outputs.release == 'true'
-        uses: EndBug/add-and-commit@v4
-        with:
-          add: ./gradle.properties
-          message: 'Updated to next SNAPSHOT version'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  release_notes:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.2
-        with:
-          fetch-depth: 0
-
-      - name: Get previous release tag
-        id: get_previous_release_tag
-        run: |
-          PREVIOUS_RELEASE_TAG=$(git tag --sort=-version:refname --merged | grep -E '^v([[:digit:]]+\.){2}[[:digit:]]+$' | head -1)
-          echo ::set-output name=previous_release_tag::$PREVIOUS_RELEASE_TAG
-
-      - name: Generate Release Notes
-        uses: enonic/release-tools/generate-changelog@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ZENHUB_TOKEN: ${{ secrets.ZENHUB_TOKEN }}
-          PREVIOS_RELEASE_TAG: ${{ steps.get_previous_release_tag.outputs.previous_release_tag }}
-          OUTPUT_FILE: changelog.md
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: changelog
-          path: changelog.md
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Companion PR to #133 (the master version-bump). Wires the `releaseBranch:` CI config on the `3.x` maintenance branch so pushes to `3.x` are recognised as release-branch builds — the `enonic/release-tools/build-and-publish` action reads `releaseBranch:` from the branch's own workflow file.

## Background

The `3.x` branch was created from `dce6290` (the post-`v3.1.0` "Updated to next SNAPSHOT version" commit on master). That commit predates the workflow modernisation on master (Apr 2024, `0592acf`), so the inherited `.github/workflows/enonic-gradle.yml` is the OLD inline build/publish pipeline with no `with:` block to extend.

## Change

Replace the OLD-style workflow on `3.x` with the same modernised workflow `master` will have after #133, including the `releaseBranch:` block listing both `master` and `3.x`. End result: master and 3.x have identical `enonic-gradle.yml` files, mirroring the app-booster `master` ↔ `1.x` reference setup.

No version bump, no docgen change, no versions.json — those remain master-only per the migration playbook.