### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 dependencies {
     implementation xplibs.api.core
     implementation xplibs.api.jaxrs
-    include 'org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:7.6.0.202603022253-r'
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:5.23.0'
+    include libs.jgit.ssh.jsch
+    testImplementation libs.junit
+    testImplementation libs.mockito.core
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,9 @@
+[versions]
+jgit    = "7.6.0.202603022253-r"
+junit   = "4.13.2"
+mockito = "5.23.0"
+
+[libraries]
+jgit-ssh-jsch = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.jsch", version.ref = "jgit" }
+junit         = { module = "junit:junit",                                version.ref = "junit" }
+mockito-core  = { module = "org.mockito:mockito-core",                   version.ref = "mockito" }


### PR DESCRIPTION
## Summary

Move inline dependency versions in `build.gradle` into a Gradle TOML
version catalog at `gradle/libs.versions.toml`. This is a pin-for-pin
migration — no versions bumped — to unify with the rest of the
IdeaProjects tree where ~half the repos already use a catalog.

### Conventions adopted

- Version keys: short, lowercase, hyphen-separated (`jgit`, `junit`,
  `mockito`).
- Library keys: full artifact name with `-` separators (`jgit-ssh-jsch`,
  `junit`, `mockito-core`).
- `[versions]` and `[libraries]` sorted alphabetically.
- `xpVersion` stays in `gradle.properties` — the rest of the toolchain
  expects it there.
- `xplibs.*` accessors untouched (those come from the XP gradle plugin,
  not the project catalog).

### Catalog

```toml
[versions]
jgit    = "7.6.0.202603022253-r"
junit   = "4.13.2"
mockito = "5.23.0"

[libraries]
jgit-ssh-jsch = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.jsch", version.ref = "jgit" }
junit         = { module = "junit:junit",                                version.ref = "junit" }
mockito-core  = { module = "org.mockito:mockito-core",                   version.ref = "mockito" }
```

### Verification

- `./gradlew build --refresh-dependencies` — green.
- `./gradlew dependencies --configuration runtimeClasspath` and
  `--configuration testRuntimeClasspath` — output identical to
  pre-migration (only timing line differs).

## Test plan

- [ ] CI passes.